### PR TITLE
Loosen Django pinned requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ description-file = "README.md"
 requires-python = ">=3.7"
 requires = [
     "pydantic==1.9.0",
-    "Django==3.2.13",
+    "Django<4",
     "typing_extensions>=3.7.4.3"
 ]
 


### PR DESCRIPTION
Thank you for creating this library. It's been very helpful in integrating pydnatic with DRF!

### What does this do

Loosens the pinned requirement from Django

### Why are we doing this

Django just made a Security release, `3.2.14`, to fix a SQL injection bug. See https://www.djangoproject.com/weblog/2022/jul/04/security-releases/ for more info

pyngo has pinned Django to 3.2.13; this is preventing us from upgrading to Django 3.2.14.

### Callouts

I'm not sure this is the best solution, but did want to make this PR to get the conversation started