### PR TITLE
Support pydantic fields with alias in `query_to_dict` function

### DIFF
--- a/pyngo/querydict.py
+++ b/pyngo/querydict.py
@@ -66,7 +66,7 @@ def querydict_to_dict(
 
         orig_value = query_dict.get(key)
         if field_key not in model_fields:
-            to_dict[field_key] = orig_value
+            to_dict[key] = orig_value
             continue
         field = model_fields[field_key]
         # Discard field if its value is empty string and we don't expect string in model
@@ -75,9 +75,9 @@ def querydict_to_dict(
         ):
             continue
         if _is_sequence_field(field):
-            to_dict[field_key] = query_dict.getlist(key)
+            to_dict[key] = query_dict.getlist(key)
         else:
-            to_dict[field_key] = query_dict.get(key)
+            to_dict[key] = query_dict.get(key)
     return to_dict
 
 

--- a/pyngo/querydict.py
+++ b/pyngo/querydict.py
@@ -62,20 +62,22 @@ def querydict_to_dict(
     model_fields = model_class.__fields__
 
     for key in query_dict.keys():
+        field_key = next((x.name for x in model_fields.values() if x.alias == key), key)
+
         orig_value = query_dict.get(key)
-        if key not in model_fields:
-            to_dict[key] = orig_value
+        if field_key not in model_fields:
+            to_dict[field_key] = orig_value
             continue
-        field = model_fields[key]
+        field = model_fields[field_key]
         # Discard field if its value is empty string and we don't expect string in model
         if orig_value in ("", b"") and not issubclass(
             field.outer_type_, (str, bytes, bytearray)
         ):
             continue
         if _is_sequence_field(field):
-            to_dict[key] = query_dict.getlist(key)
+            to_dict[field_key] = query_dict.getlist(key)
         else:
-            to_dict[key] = query_dict.get(key)
+            to_dict[field_key] = query_dict.get(key)
     return to_dict
 
 

--- a/tests/querydict_test.py
+++ b/tests/querydict_test.py
@@ -19,6 +19,7 @@ class Model(QueryDictModel, BaseModel):
     wings: Tuple[int, ...] = Field(default_factory=tuple)
     queue: Deque[int] = Field(default_factory=deque)
     basket: FrozenSet[int] = Field(default_factory=frozenset)
+    alias_list: List[int] = Field(alias="alias[list]", default_factory=list)
 
 
 @pytest.mark.parametrize(
@@ -47,6 +48,10 @@ class Model(QueryDictModel, BaseModel):
             QueryDict("foo=8&bar=9&basket=5&basket=6"),
             Model(foo=8, bar=[9], basket=frozenset((5, 6))),
         ),
+        (
+            QueryDict("foo=8&bar=9&basket=5&basket=6&alias[list]=5&alias[list]=3"),
+            Model(foo=8, bar=[9], basket=frozenset((5, 6)), alias_list=[5, 3]),
+        ),
     ),
 )
 def test_parsing_objects(
@@ -61,3 +66,4 @@ def test_parsing_objects(
     assert got.wings == expected.wings
     assert got.queue == expected.queue
     assert got.basket == expected.basket
+    assert got.alias_list == expected.alias_list

--- a/tests/querydict_test.py
+++ b/tests/querydict_test.py
@@ -50,7 +50,9 @@ class Model(QueryDictModel, BaseModel):
         ),
         (
             QueryDict("foo=8&bar=9&basket=5&basket=6&alias[list]=5&alias[list]=3"),
-            Model(foo=8, bar=[9], basket=frozenset((5, 6)), alias_list=[5, 3]),
+            # This has to  be a dictionary due to the invalid characters in alias[list]
+            # Which has to be set because that's what the model is looking for via the Field alias
+            Model(**{'foo':8, 'bar': [9], 'basket': frozenset((5, 6)), 'alias[list]': [5, 3]}),
         ),
     ),
 )

--- a/tests/querydict_test.py
+++ b/tests/querydict_test.py
@@ -52,7 +52,14 @@ class Model(QueryDictModel, BaseModel):
             QueryDict("foo=8&bar=9&basket=5&basket=6&alias[list]=5&alias[list]=3"),
             # This has to  be a dictionary due to the invalid characters in alias[list]
             # Which has to be set because that's what the model is looking for via the Field alias
-            Model(**{'foo':8, 'bar': [9], 'basket': frozenset((5, 6)), 'alias[list]': [5, 3]}),
+            Model(
+                **{
+                    "foo": 8,
+                    "bar": [9],
+                    "basket": frozenset((5, 6)),
+                    "alias[list]": [5, 3],
+                }
+            ),
         ),
     ),
 )


### PR DESCRIPTION
Sometimes QueryDict parameters will have invalid characters that cannot be used as modelfield names. Pydantic supports `alias` for this on its Field class.

pyngo doesn't check for an alias in the modelfield, so if you have an alias set, the returned data is invalid if the data is supposed to be of a sequence type, as it only uses `get` on the QueryDict, even though the model expects a list.

The added test should highlight the issue this patch addresses