### PR TITLE
Migrate to Pydantic v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", 3.11, 3.12]
       fail-fast: false
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", 3.11, 3.12]
+        python-version: ["3.10"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.8","3.9","3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.1.9
     hooks:
     -   id: ruff
         args:

--- a/pyngo/errors.py
+++ b/pyngo/errors.py
@@ -15,17 +15,17 @@ def drf_error_details(exception: ValidationError) -> Dict[str, Any]:
     """
     drf_data: Dict[str, Any] = {}
     for error in exception.errors():
-        set_nested(drf_data, error["loc"], [error["msg"]])  # type: ignore
+        set_nested(drf_data, error["loc"], [error["msg"]])
     return drf_data
 
 
-def set_nested(data: Dict[str, Any], keys: Sequence[str], value: Any) -> None:
+def set_nested(data: Dict[str, Any], keys: tuple[int | str, ...], value: Any) -> None:
     """
     Set a value in a nested dictionary.
 
     Args:
         data (Dict[str, Any]): The dictionary to set the value in.
-        keys (Sequence[str]): The keys to set the value at.
+        keys (tuple[int | str, ...]): The keys to set the value at.
         value (Any): The value to set.
 
     Returns:
@@ -33,7 +33,7 @@ def set_nested(data: Dict[str, Any], keys: Sequence[str], value: Any) -> None:
     """
     for key in keys[:-1]:
         data = data.setdefault(str(key), {})
-    data[keys[-1]] = value
+    data[str(keys[-1])] = value
 
 
 def get_nested(data: Dict[str, Any], keys: Sequence[str]) -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "pyngo"
 description = "Pydantic Package for Adding Models into a Django or Django Rest Framework Project ✨"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "MIT"
 authors = [
     { name = "Yasser Tahiri", email = "hello@yezz.me" },
@@ -20,8 +20,6 @@ classifiers = [
     "Natural Language :: English",
     "Framework :: Django",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -32,7 +30,7 @@ classifiers = [
 
 dependencies = [
     "typing-extensions >=3.7.4,<4.10.0",
-    "pydantic >=1.8.2,<2.0.0",
+    "pydantic>=2.5.3",
     "Django >=3.2.0,<6.0.0",
 ]
 
@@ -46,6 +44,7 @@ Funding = 'https://github.com/sponsors/yezz123'
 lint = [
     "pre-commit==3.6.0",
     "mypy==1.8.0",
+    "ruff==0.1.9",
 ]
 test = [
     "pytest==7.4.3",

--- a/tests/openapi_test.py
+++ b/tests/openapi_test.py
@@ -17,7 +17,7 @@ class TestPydanticModelToOpenapiParameters:
 
     def test_prohibits_unknown_location(self) -> None:
         class Model(BaseModel):
-            path_param: int = Field(location="foo")
+            path_param: int = Field(json_schema_extra={"location": "foo"})
 
         with pytest.raises(ValueError) as exc:
             openapi_params(Model)
@@ -25,7 +25,7 @@ class TestPydanticModelToOpenapiParameters:
 
     def test_prohibits_optional_path_params(self) -> None:
         class Model(BaseModel):
-            path_param: Optional[int] = Field(location="path")
+            path_param: Optional[int] = Field(default=0, json_schema_extra={"location": "path"})
 
         with pytest.raises(ValueError) as exc:
             openapi_params(Model)
@@ -33,7 +33,7 @@ class TestPydanticModelToOpenapiParameters:
 
     def test_defaults_path_params_to_be_required(self) -> None:
         class Model(BaseModel):
-            path_param: int = Field(location="path")
+            path_param: int = Field(json_schema_extra={"location": "path"})
 
         params = openapi_params(Model)
         assert len(params) == 1
@@ -42,7 +42,7 @@ class TestPydanticModelToOpenapiParameters:
     @pytest.mark.parametrize("param_loc", ("header", "path", "cookie"))
     def test_prohibits_allow_empty_outside_of_query(self, param_loc: str) -> None:
         class Model(BaseModel):
-            param: int = Field(location=param_loc, allowEmptyValue=True)
+            param: int = Field(json_schema_extra={"location": param_loc, "allowEmptyValue": True})
 
         with pytest.raises(ValueError) as exc:
             openapi_params(Model)
@@ -50,7 +50,7 @@ class TestPydanticModelToOpenapiParameters:
 
     def test_allow_empty_excluded_for_non_query_params(self) -> None:
         class Model(BaseModel):
-            param: int = Field(location="header")
+            param: int = Field(json_schema_extra={"location": "header"})
 
         params = openapi_params(Model)
         assert len(params) == 1
@@ -74,7 +74,7 @@ class TestPydanticModelToOpenapiParameters:
 
     def test_optional_fields_are_not_required(self) -> None:
         class Model(BaseModel):
-            param: Optional[int] = Field()
+            param: Optional[int] = Field(default=0)
 
         params = openapi_params(Model)
         assert len(params) == 1
@@ -83,11 +83,12 @@ class TestPydanticModelToOpenapiParameters:
     def test_reading_query_params(self) -> None:
         class PathParams(BaseModel):
             document_id: int = Field(
-                location="query",
                 description="The document id",
-                required=True,
-                deprecated=True,
-                allowEmptyValue=True,
+                json_schema_extra={
+                    "location": "query",
+                    "deprecated": True,
+                    "allowEmptyValue": True,
+                },
             )
 
         expected_parameters = [

--- a/tests/querydict_test.py
+++ b/tests/querydict_test.py
@@ -14,7 +14,7 @@ os.environ["DJANGO_SETTINGS_MODULE"] = "tests.settings"
 class Model(QueryDictModel, BaseModel):
     foo: int
     bar: List[int]
-    sub_id: Optional[int]
+    sub_id: Optional[int] = None
     key: str = "key"
     wings: Tuple[int, ...] = Field(default_factory=tuple)
     queue: Deque[int] = Field(default_factory=deque)
@@ -62,7 +62,7 @@ class Model(QueryDictModel, BaseModel):
     ),
 )
 def test_parsing_objects(data: Union[QueryDict, Dict[str, Any]], expected: Model) -> None:
-    got = Model.parse_obj(data)
+    got = Model.model_validate(data)
     assert got == expected
     assert got.foo == expected.foo
     assert got.bar == expected.bar


### PR DESCRIPTION
Fixes #70 

What changes:

- Work with Pydantic v2 (not work with Pydantic v1, due to drastic change in Pydantic API).
- Raise minimum Python to 3.10, to support Django 5.0

You may notice change in testing data, about how to define "required" field. Look [here](https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields) for how it changed.