### PR TITLE
Fix nested model validation example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ class Framework(BaseModel):
 class Language(BaseModel):
    framework: List[Framework]
 
-data = {"Framework": [{"frm_id": "not_a_number"}, {}]}
+data = {"framework": [{"frm_id": "not_a_number"}, {}]}
 expected_details = {
    "framework": {
       "0": {"frm_id": ["value is not a valid integer"]},
@@ -167,7 +167,7 @@ expected_details = {
 }
 
 try:
-   Framework.parse_obj(data)
+   Language.parse_obj(data)
 except ValidationError as e:
    print(drf_error_details(e))
 ```


### PR DESCRIPTION
It's possible I misunderstood the intention of the example, but I think there's an error there.  The updates included in this PR produce the `expected_details` (closely enough).

Not a biggie, but may prevent confusion for future `pyngo` users.

Thanks for the great package!